### PR TITLE
Poopdark filter change

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -206,12 +206,12 @@
 	if(!.)
 		return
 	remove_filter("AO")
-	remove_filter("spook_color")
+	remove_filter("spook_color") // ARK STATION ADDITION
 	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
 
-	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/poopdark_filter))
-		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
+	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/poopdark_filter)) // ARK STATION ADDITION
+		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.10,0, 0.13,0.7,0.10,0, 0.13,0.13,0.75,0, -0.02,-0.03,-0.04,1, 0,0,0,0))) // ARK STATION ADDITION
 
 ///Contains all lighting objects
 /atom/movable/screen/plane_master/rendering_plate/lighting

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -270,7 +270,7 @@ em {
 }
 
 .ooc {
-  color: #00b300; // ARK STATION EDIT
+  color: #c88800; // ARK STATION EDIT
   font-weight: bold;
 }
 

--- a/zov_modular_arkstation/modules/poopdark-filter/code.dm
+++ b/zov_modular_arkstation/modules/poopdark-filter/code.dm
@@ -2,3 +2,4 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "poopdark_filter"
 	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE // CHANGED FROM TRUE


### PR DESCRIPTION

## About The Pull Request

Поменял пупдарк фильтр. Он стал в два раза ярче, чем был.
Теперь он так же отключен по умолчанию.
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing

Без фильтра:
![image](https://github.com/ArkStation13/Ark-Station-13/assets/104254674/f4705133-b639-45fd-85c1-572aa396ac65)
С фильтром:
![image](https://github.com/ArkStation13/Ark-Station-13/assets/104254674/cba739e0-2a70-45ac-805e-a4134a25f73b)
Было раньше:
![image](https://github.com/ArkStation13/Ark-Station-13/assets/104254674/613853d7-201d-4887-81f7-6496aee04b29)
## Changelog
:cl:
refactor: Чутка переработан пупдарк фильтр.
/:cl:
