### PR TITLE
Убираем шлепанье головой о шлюз

### DIFF
--- a/modular_nova/modules/oversized/code/door.dm
+++ b/modular_nova/modules/oversized/code/door.dm
@@ -19,4 +19,4 @@
 				span_userdanger("You slam your head against [src]!")
 			)
 			playsound(crossed_atom, 'sound/effects/bang.ogg', 50, TRUE)
-/* ARK - oversize_changes - END
+/ ARK - oversize_changes - END*/

--- a/modular_nova/modules/oversized/code/door.dm
+++ b/modular_nova/modules/oversized/code/door.dm
@@ -1,3 +1,4 @@
+/* ARK - oversize_changes - START - убираем шлепанье головой о шлюзы
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
 	var/static/list/loc_connections = list(
@@ -18,3 +19,4 @@
 				span_userdanger("You slam your head against [src]!")
 			)
 			playsound(crossed_atom, 'sound/effects/bang.ogg', 50, TRUE)
+/* ARK - oversize_changes - END


### PR DESCRIPTION
Персонажи с квирком oversized больше не стукаются головой, когда проходят через шлюз на режиме бега.