### PR TITLE
[PORT] Добавлена загрузка из префов для битранеров.

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -60,8 +60,8 @@
 		var/datum/action/avatar_domain_info/action = new(help_datum)
 		action.Grant(avatar)
 
-	var/client/our_client = avatar.client
-	var/alias = our_client?.prefs?.read_preference(/datum/preference/name/hacker_alias) || pick(GLOB.hacker_aliases)
+	//var/client/our_client = avatar.client
+	var/alias = null // ARK STATION EDIT - removes random aliases - original: our_client?.prefs?.read_preference(/datum/preference/name/hacker_alias) || pick(GLOB.hacker_aliases)
 
 	if(alias && avatar.real_name != alias)
 		avatar.fully_replace_character_name(avatar.real_name, alias)

--- a/code/modules/bitrunning/netpod/utils.dm
+++ b/code/modules/bitrunning/netpod/utils.dm
@@ -87,6 +87,15 @@
 		if(isnull(current_avatar))
 			balloon_alert(neo, "out of bandwidth!")
 			return
+		// ARK STATION EDIT BEGIN - PREFS!
+		var/datum/preferences/pref
+		var/load_loadout = FALSE
+		var/obj/item/bitrunning_disk/prefs/prefdisk = locate() in neo.get_contents()
+		if(prefdisk)
+			load_loadout = prefdisk.include_loadout
+			pref = prefdisk.loaded_preference
+		current_avatar = server.generate_avatar(wayout, netsuit, pref, include_loadout = load_loadout)  // Added the prefs argument
+		// ARK STATION EDIT END
 
 	neo.set_static_vision(2 SECONDS)
 	add_healing(occupant)

--- a/code/modules/bitrunning/netpod/utils.dm
+++ b/code/modules/bitrunning/netpod/utils.dm
@@ -87,15 +87,6 @@
 		if(isnull(current_avatar))
 			balloon_alert(neo, "out of bandwidth!")
 			return
-		// ARK STATION EDIT BEGIN - PREFS!
-		var/datum/preferences/pref
-		var/load_loadout = FALSE
-		var/obj/item/bitrunning_disk/prefs/prefdisk = locate() in neo.get_contents()
-		if(prefdisk)
-			load_loadout = prefdisk.include_loadout
-			pref = prefdisk.loaded_preference
-		current_avatar = server.generate_avatar(wayout, netsuit, pref, include_loadout = load_loadout)  // Added the prefs argument
-		// ARK STATION EDIT END
 
 	neo.set_static_vision(2 SECONDS)
 	add_healing(occupant)

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -38,9 +38,14 @@
 
 
 /// Generates a new avatar for the bitrunner.
-/obj/machinery/quantum_server/proc/generate_avatar(turf/destination, datum/outfit/netsuit)
+/obj/machinery/quantum_server/proc/generate_avatar(turf/destination, datum/outfit/netsuit, datum/preferences/prefs, load_loadout = FALSE) // ARK STATION EDIT - Prefs and loadout argument
 	var/mob/living/carbon/human/avatar = new(destination)
 
+	// ARK STATION EDIT BEGIN - PREFS!
+	if(!isnull(prefs))
+		prefs.safe_transfer_prefs_to(avatar)
+	ADD_TRAIT(avatar, TRAIT_CANNOT_CRYSTALIZE, "Bitrunning") // Stops the funny ethereal bug
+	// ARK STATION EDIT END
 	var/outfit_path = generated_domain.forced_outfit || netsuit
 	var/datum/outfit/to_wear = new outfit_path()
 
@@ -76,6 +81,9 @@
 			new /obj/item/storage/medkit/regular,
 			new /obj/item/flashlight,
 		)
+
+	if(load_loadout)
+		avatar.equip_outfit_and_loadout(new /datum/outfit(), prefs) // ARK STATION EDIT - LOADOUTS
 
 	var/obj/item/card/id/outfit_id = avatar.wear_id
 	if(outfit_id)

--- a/code/modules/bitrunning/server/threats.dm
+++ b/code/modules/bitrunning/server/threats.dm
@@ -176,7 +176,7 @@
 /// Removes any invalid candidates from the list
 /obj/machinery/quantum_server/proc/validate_mutation_candidates()
 	for(var/datum/weakref/creature_ref as anything in mutation_candidate_refs)
-		var/mob/living/creature = creature_ref.resolve()
+		var/mob/living/creature = creature_ref?.resolve() // ARK STATION EDIT - REF CHECK for RUNTIME AVOIDANCE
 		if(isnull(creature) || creature.mind)
 			mutation_candidate_refs.Remove(creature_ref)
 

--- a/code/modules/bitrunning/server/util.dm
+++ b/code/modules/bitrunning/server/util.dm
@@ -148,7 +148,15 @@
 	if(isnull(entry_atom))
 		return
 
-	var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit)
+	// ARK STATION EDIT BEGIN - PREFS!
+	var/datum/preferences/pref
+	var/load_loadout = FALSE
+	var/obj/item/bitrunning_disk/prefs/prefdisk = locate() in neo.get_contents()
+	if(prefdisk)
+		load_loadout = prefdisk.include_loadout
+		pref = prefdisk.loaded_preference
+	var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit, prefs = pref, load_loadout = load_loadout)  // Added the prefs argument
+	// ARK STATION EDIT END
 	stock_gear(new_avatar, neo, generated_domain)
 
 	// Cleanup for domains with one time use custom spawns

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8636,6 +8636,7 @@
 #include "zov_modular_arkstation\_master_files\code\modules\antagonists\traitor\objectives\assassination.dm"
 #include "zov_modular_arkstation\_master_files\code\modules\asset_cache\assets\inventory.dm"
 #include "zov_modular_arkstation\_master_files\code\modules\autolathe_components_adv\advpartdisks.dm"
+#include "zov_modular_arkstation\_master_files\code\modules\bitrunning\disks.dm"
 #include "zov_modular_arkstation\_master_files\code\modules\client\client_procs.dm"
 #include "zov_modular_arkstation\_master_files\code\modules\client\preferences\clothing.dm"
 #include "zov_modular_arkstation\_master_files\code\modules\client\preferences\player_panel.dm"

--- a/zov_modular_arkstation/_master_files/code/modules/bitrunning/disks.dm
+++ b/zov_modular_arkstation/_master_files/code/modules/bitrunning/disks.dm
@@ -1,0 +1,51 @@
+/obj/item/bitrunning_disk/prefs
+	name = "DeForest biological simulation disk"
+	desc = "A disk containing the biological simulation data necessary to load custom characters into bitrunning domains."
+	icon = 'icons/obj/devices/circuitry_n_data.dmi'
+	base_icon_state = "datadisk"
+	icon_state = "datadisk0"
+
+	w_class = WEIGHT_CLASS_SMALL
+
+	var/datum/preferences/loaded_preference
+
+	var/include_loadout = FALSE
+
+/obj/item/bitrunning_disk/prefs/examine(mob/user)
+	. = ..()
+	if(!isnull(loaded_preference))
+		var/name = loaded_preference.read_preference(/datum/preference/name/real_name)
+		. += "It currently has the character [name] loaded, with loadouts [(include_loadout ? "enabled" : "disabled")]"
+		. += span_notice("Ctrl-Click to change loadout loading")
+
+/obj/item/bitrunning_disk/prefs/item_ctrl_click(mob/user)
+	include_loadout = !include_loadout // We just switch this around. Elegant!
+	balloon_alert(user, include_loadout ? "Loadout enabled" : "Loadout disabled")
+
+/obj/item/bitrunning_disk/prefs/attack_self(mob/user, modifiers)
+	. = ..()
+
+	var/list/prefdata_names = user.client.prefs?.create_character_profiles()
+	if(isnull(prefdata_names))
+		return
+
+	var/response = tgui_alert(user, message = "Change selected prefs?", title = "Prefchange", buttons = list("Yes", "No"))
+	if(isnull(response) || response == "No")
+		return
+	var/choice = tgui_input_list(user, message = "Select a character",  title = "Character selection", items = prefdata_names)
+	if(isnull(choice) || !user.is_holding(src))
+		return
+
+	loaded_preference = new(user.client)
+	loaded_preference.load_character(prefdata_names.Find(choice))
+
+	balloon_alert(user, "Character set")
+	to_chat(user, span_notice("Character set to [choice] sucessfully!"))
+
+/datum/outfit/job/bitrunner
+	r_pocket = /obj/item/bitrunning_disk/prefs
+
+/datum/orderable_item/bitrunning_tech/pref_item
+	cost_per_order = 500
+	item_path = /obj/item/bitrunning_disk/prefs
+	desc = "This disk contains a program that lets you load in custom characters."


### PR DESCRIPTION
## О вашем Пулл Реквесте
Добавляем диск битранерам для загрузки своих персонажей..
Мелкие исправления в коде.
Портировано с https://github.com/Bubberstation/Bubberstation
## Скриншоты и Видео тестирования
![image](https://github.com/user-attachments/assets/561888cc-d082-4e6c-98d0-7d9a5def6a5a)
![image](https://github.com/user-attachments/assets/ac70584b-3b73-4ddf-b2f1-8c1d32212a77)
![image](https://github.com/user-attachments/assets/26d13a97-2d57-460e-b516-6426cf5586f0)

## Changelog

:cl:
add: Добавлена загрузка из префов для битранеров с помощью специального диска.
fix: Исправлен лодаут и имена для битранеров.
fix: Мелкие исправления ошибок и потеницального рантайма в коде битранеров.
/:cl:
