### PR TITLE
Minor fix of the Ark hermit ruins 

### DIFF
--- a/_maps/ark_map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/ark_map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -255,7 +255,7 @@
 /area/ruin/powered/hermit)
 "NR" = (
 /obj/structure/mineral_door/wood/large_gate,
-/turf/closed/wall/mineral/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/hermit)
 "Pa" = (
 /obj/structure/reagent_water_basin,


### PR DESCRIPTION
## О вашем Пулл Реквесте
Небольшое исправление на карте руин Арка с хермитами. 
Ошибочно установленные стены заменены на пол.
## Скриншоты и Видео тестирования
![image](https://github.com/user-attachments/assets/08ea0f1f-14b4-4d05-8ed1-9ace5eb8a413)

## Changelog

:cl:
fix: Убраны блокирующие стены у хермитов на Лаваленде.
/:cl:
