### PR TITLE
Fix-apc-NT

### DIFF
--- a/_maps/ark_map_files/ark_maps/wawastation.dmm
+++ b/_maps/ark_map_files/ark_maps/wawastation.dmm
@@ -46556,7 +46556,7 @@
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/nt_rep)
+/area/station/command/meeting_room)
 "pXp" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed{


### PR DESCRIPTION
Пофиксил зону АПЦ, предназначенной для другой зоны.

:cl:
fix: зона апц
/:cl:
